### PR TITLE
Update to stanford-corenlp to 3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Controls which Stanford NER Model to use while extracting entities:
 
 # Developing
 
-You need maven and java (1.7).  We develop in Eclipse Kepler: Java EE.
+You need maven and java (1.8).  We develop in Eclipse Kepler: Java EE.
 
 ## Eclipse & Java on Mac
 You might need to update your version of the JRE for developing on Mac. If so, you can do:

--- a/stanford-entity-extractor/pom.xml
+++ b/stanford-entity-extractor/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>edu.stanford.nlp</groupId>
 			<artifactId>stanford-corenlp</artifactId>
-			<version>3.4.1</version>
+			<version>3.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.kohsuke.metainf-services</groupId>

--- a/stanford-entity-extractor/src/main/java/org/mediameter/cliff/stanford/StanfordNamedEntityExtractor.java
+++ b/stanford-entity-extractor/src/main/java/org/mediameter/cliff/stanford/StanfordNamedEntityExtractor.java
@@ -96,8 +96,7 @@ public class StanfordNamedEntityExtractor implements EntityExtractor {
         InputStream mpis = this.getClass().getClassLoader().getResourceAsStream("models/" + NERprop);
         Properties mp = new Properties();
         mp.load(mpis);
-        namedEntityRecognizer = (AbstractSequenceClassifier<CoreMap>)
-                CRFClassifier.getJarClassifier("/models/" + NERmodel, mp);
+        namedEntityRecognizer = CRFClassifier.getClassifier("models/" + NERmodel, mp);
     }
 
     /**


### PR DESCRIPTION
Java 1.8+ will be required going forward do to stanford-corenlp deprecating 1.7 in version 3.5.0 [1]
Will need PR #64 to fix GeoNameAncestryTest

[1] https://stanfordnlp.github.io/CoreNLP/history.html